### PR TITLE
fix open_clip nonscalar_logit_scale param

### DIFF
--- a/configs/DFN5B-CLIP-ViT-H-14-384.json
+++ b/configs/DFN5B-CLIP-ViT-H-14-384.json
@@ -2,6 +2,7 @@
     "model_cfg": {
         "embed_dim": 1024,
         "quick_gelu": true,
+        "nonscalar_logit_scale": true,
         "vision_cfg": {
             "image_size": 378,
             "layers": 32,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ torchdiffeq>=0.2.3
 einops>=0.7.0
 timm>=1.0.8
 omegaconf>=2.3.0
-open_clip_torch>=2.29.0
+open_clip_torch>=2.32.0
 accelerate


### PR DESCRIPTION
open_clip_torch version 2.32.0 introduced the `nonscalar_logit_scale` parameter during CLIP initialization. By default (`nonscalar_logit_scale=False`), logit_scale is set as a scalar. This default setting can lead to errors when loading the CLIP model.

```
Trying to set a tensor of shape torch.Size([1]) in "logit_scale" (which has shape torch.Size([])), this looks incorrect.
```